### PR TITLE
Fix documentation workflow permissions and update action version

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -153,6 +153,28 @@ ctest
 ./generate_coverage.ps1
 ```
 
+## GitHub Actions & Documentation
+
+### Documentation Workflow
+The project uses GitHub Actions to automatically generate and deploy Doxygen documentation:
+- **Triggered by**: pushes to main/master branches, version tags, or manual dispatch
+- **Generates**: Doxygen HTML documentation from source code comments
+- **Deploys to**: GitHub Pages and a `documentation` branch
+
+### Workflow Permissions
+The documentation workflow requires `contents: write` permission to push to the documentation branch:
+```yaml
+permissions:
+  contents: write  # Required for pushing to documentation branch
+  pages: write     # Required for GitHub Pages deployment
+  id-token: write  # Required for GitHub Pages authentication
+```
+
+### Troubleshooting Workflow Issues
+- **Permission denied errors**: Ensure the workflow has `contents: write` permission
+- **Documentation generation failures**: Check Doxyfile syntax and source code comments
+- **Deployment failures**: Verify the `peaceiris/actions-gh-pages` action is up to date (v4+)
+
 ## Common Operations
 
 ### Adding New Test Cases

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write  # Changed from 'read' to 'write' to allow pushing to documentation branch
   pages: write
   id-token: write
 
@@ -142,7 +142,7 @@ jobs:
           touch docs/html/.nojekyll
 
       - name: Deploy to documentation branch
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/html


### PR DESCRIPTION
This pull request improves the automation and documentation of the project's Doxygen documentation deployment process. It updates workflow permissions, documentation, and the deployment action version to ensure smoother and more secure publishing of documentation to GitHub Pages.

**Documentation and workflow improvements:**

* Added a new section to `.github/copilot-instructions.md` explaining the GitHub Actions workflow for generating and deploying Doxygen documentation, including triggers, permissions, and troubleshooting tips.

**Workflow configuration updates:**

* Changed the `contents` permission from `read` to `write` in `.github/workflows/documentation.yml` to allow the workflow to push updates to the documentation branch.
* Upgraded the deployment action from `peaceiris/actions-gh-pages@v3` to `v4` in `.github/workflows/documentation.yml` for improved reliability and compatibility.