### PR TITLE
Fix PowerShell 5.x compatibility in check-format script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,11 +327,11 @@ jobs:
 
             # Get base filename for checking generated files
             base_name=$(basename "$expr_file" .txt)
-            
+
             # Check if BDD DOT file was created and is valid
             bdd_dot_file="${base_name}_bdd.dot"
             tree_dot_file="${base_name}_expression_tree.dot"
-            
+
             if [ -f "$bdd_dot_file" ]; then
               dot -Tpng "$bdd_dot_file" -o /tmp/test_bdd.png || {
                 echo "❌ Invalid BDD DOT file: $bdd_dot_file"
@@ -341,7 +341,7 @@ jobs:
             else
               echo "⚠️  No BDD DOT file generated for $expr_file"
             fi
-            
+
             if [ -f "$tree_dot_file" ]; then
               dot -Tpng "$tree_dot_file" -o /tmp/test_tree.png || {
                 echo "❌ Invalid expression tree DOT file: $tree_dot_file"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,7 +138,7 @@ void write_bdd_nodes_to_stream(const teddy::bdd_manager& manager,
  * @param suffix String to append to the base filename
  * @return New filesystem path with the suffix added
  *
- * Example: input_filepath="test/expr.txt", suffix="_bdd" → "test/expr_bdd"
+ * Example: input_filepath="test/expr.txt", suffix="_bdd" -> "test/expr_bdd"
  */
 std::filesystem::path get_output_path(const std::filesystem::path& input_filepath,
                                       const std::string& suffix) {
@@ -166,11 +166,11 @@ std::filesystem::path get_output_path(const std::filesystem::path& input_filepat
  * @throws std::runtime_error If a variable reference is not found during conversion
  *
  * Operator mappings:
- * - AND → BDD AND operation
- * - OR → BDD OR operation
- * - XOR → BDD XOR operation
- * - NOT → XOR with constant 1
- * - Variable → BDD variable node
+ * - AND -> BDD AND operation
+ * - OR -> BDD OR operation
+ * - XOR -> BDD XOR operation
+ * - NOT -> XOR with constant 1
+ * - Variable -> BDD variable node
  */
 teddy::bdd_manager::diagram_t convert_to_bdd(const my_expression& expr, teddy::bdd_manager& mgr) {
     using bdd_t = teddy::bdd_manager::diagram_t;


### PR DESCRIPTION
- Replace Unicode emoji characters with ASCII equivalents
- Ensure Windows PowerShell 5.1 compatibility for git hooks
- Fix string comparison logic for formatting detection
- Scripts now work with both PowerShell 5.x and 7.x

This pull request primarily standardizes and clarifies output messages in the `scripts/check-format.ps1` script by replacing emoji-based status indicators with consistent, bracketed text tags (e.g., `[INFO]`, `[OK]`, `[ERROR]`). Additionally, it improves the formatting check logic for C++ files and makes minor documentation corrections in `src/main.cpp`.

**Improvements to formatting script output and logic:**

* Replaced emoji-based output messages in `scripts/check-format.ps1` with bracketed tags like `[INFO]`, `[OK]`, `[WARN]`, `[ERROR]`, `[FAIL]`, `[SUCCESS]`, and `[TIP]` for clearer and more consistent status reporting. [[1]](diffhunk://#diff-9508b48face0fc02bee1d3d0a27bdbb2d7ce9acb550c7b2af47b592d811d10bbL77-R99) [[2]](diffhunk://#diff-9508b48face0fc02bee1d3d0a27bdbb2d7ce9acb550c7b2af47b592d811d10bbL131-R138) [[3]](diffhunk://#diff-9508b48face0fc02bee1d3d0a27bdbb2d7ce9acb550c7b2af47b592d811d10bbL151-R151) [[4]](diffhunk://#diff-9508b48face0fc02bee1d3d0a27bdbb2d7ce9acb550c7b2af47b592d811d10bbL161-R228) [[5]](diffhunk://#diff-9508b48face0fc02bee1d3d0a27bdbb2d7ce9acb550c7b2af47b592d811d10bbL227-R244)
* Enhanced the formatting check logic to normalize line endings and trim trailing whitespace before comparing formatted and original file contents, reducing false positives due to line ending differences.
* Improved verbose diff output: now only shows up to 10 lines of differences, includes a message if no differences are found (potentially due to line endings), and clarifies the output for easier debugging.

**Documentation and comment corrections:**

* Updated example and operator mapping comments in `src/main.cpp` to use ASCII arrows (`->`) instead of Unicode arrows for improved readability and compatibility. [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L141-R141) [[2]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L169-R173)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal formatting validation with improved status messaging and file selection options
  * Updated developer documentation with ASCII formatting for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->