### PR TITLE
Pin fetched projects by commit hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,14 +124,14 @@ include(cmake/FetchAndPatch.cmake)
 # Fetch and patch TeDDy library from GitHub
 fetch_and_patch(DecisionDiagrams
     GIT_REPOSITORY https://github.com/MichalMrena/DecisionDiagrams.git
-    GIT_TAG v4.1.0
+    GIT_TAG a5b73864106d98ae407095033e75b0bc29fc22af
     PATCHES_DIR ${CMAKE_SOURCE_DIR}/patches/teddy
 )
 
 # Fetch and patch CUDD library from GitHub
 fetch_and_patch(CUDD
     GIT_REPOSITORY https://github.com/cuddorg/cudd.git
-    GIT_TAG 4.0.0
+    GIT_TAG b7b1ca9f35d86e2437ba35be9e5335222c524da0
     PATCHES_DIR ${CMAKE_SOURCE_DIR}/patches/cudd
 )
 


### PR DESCRIPTION
This pull request updates the dependencies for the TeDDy and CUDD libraries by changing the specific git commit hashes used in the build process. No other changes are included. 

Dependency updates:

* Updated the `DecisionDiagrams` (TeDDy) library to use commit `a5b73864106d98ae407095033e75b0bc29fc22af` instead of the previous tag `v4.1.0` in `CMakeLists.txt`.
* Updated the `CUDD` library to use commit `b7b1ca9f35d86e2437ba35be9e5335222c524da0` instead of the previous tag `4.0.0` in `CMakeLists.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to specific commit versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->