### PR TITLE
Add expression_view adapter and tests

### DIFF
--- a/include/cudd_view.hpp
+++ b/include/cudd_view.hpp
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) 2025 Alan Jowett
+/**
+ * @file cudd_view.hpp
+ * @brief Adapter exposing a CUDD DdNode graph as a graph::external_dag_view
+ *
+ * This adapter wraps raw CUDD pointers (DdNode*) and presents a small
+ * view type that models `graph::external_dag_view` used by the generic graph
+ * algorithms. The adapter preserves CUDD complement-edge semantics by
+ * returning child handles that include the complement bit when appropriate.
+ */
+#pragma once
+
+#include <cudd/cudd.h>
+
+#include <cstdint>
+#include <cudd/cuddObj.hh>
+#include <vector>
+
+#include "graph_concepts.hpp"
+
+/**
+ * @brief CUDD-backed external_dag_view adapter
+ *
+ * Exposes a minimal view over CUDD `DdNode*` values. The nested types
+ * `handle` and `edge` model the `graph::node_handle` and `graph::edge_ref`
+ * concepts respectively. `children()` returns a small `std::vector<edge>` to
+ * simplify iterator/range compatibility across compilers.
+ */
+struct cudd_view {
+    /**
+     * @brief Lightweight handle wrapper for a CUDD node pointer
+     *
+     * `stable_key()` encodes the raw pointer value (including the
+     * complement bit) so that logically distinct addressed nodes remain
+     * distinct for memoization and hashing in algorithms.
+     */
+    struct handle {
+        DdNode* p = nullptr;
+
+        std::uint64_t stable_key() const noexcept {
+            return static_cast<std::uint64_t>(reinterpret_cast<std::uintptr_t>(p));
+        }
+
+        /**
+         * @brief Optional debug pointer for diagnostics
+         * @return pointer value suitable for printing or address comparisons
+         */
+        const void* debug_address() const noexcept {
+            return static_cast<const void*>(p);
+        }
+
+        friend bool operator==(const handle& a, const handle& b) noexcept {
+            return a.p == b.p;
+        }
+        friend bool operator!=(const handle& a, const handle& b) noexcept {
+            return a.p != b.p;
+        }
+    };
+
+    /**
+     * @brief Edge reference returned by `children()`
+     *
+     * `label()` encodes branch semantics: 0 == else/low, 1 == then/high.
+     */
+    struct edge {
+        handle tgt;
+        int branch = 0;  // 0 = else/low, 1 = then/high
+        handle target() const noexcept {
+            return tgt;
+        }
+        int label() const noexcept {
+            return branch;
+        }
+    };
+
+    /// CUDD manager pointer used for helper functions (may be nullptr for some tests)
+    const Cudd* manager = nullptr;
+    /// The root DdNode pointer for this view
+    DdNode* root = nullptr;
+
+    cudd_view() = default;
+    cudd_view(const Cudd* m, DdNode* r) : manager(m), root(r) {}
+
+    /**
+     * @brief Return child edges for node handle `h`
+     *
+     * Returns an empty vector for null or constant nodes. For non-constant
+     * nodes the `low` and `high` children are returned. If the supplied
+     * handle pointer is complemented, the complement bit is propagated to
+     * the returned children so callers can treat handles as opaque stable
+     * identifiers.
+     *
+     * @param h Node handle to query
+     * @return small vector of `edge` describing the outgoing children
+     */
+    auto children(handle h) const {
+        std::vector<edge> out;
+        DdNode* node = h.p;
+        if (!node)
+            return out;
+
+        DdNode* regular = Cudd_Regular(node);
+        if (Cudd_IsConstant(regular))
+            return out;
+
+        DdNode* low = Cudd_E(regular);
+        DdNode* high = Cudd_T(regular);
+
+        // If the parent pointer was complemented, children must be complemented
+        if (Cudd_IsComplement(node)) {
+            low = Cudd_Not(low);
+            high = Cudd_Not(high);
+        }
+
+        if (low)
+            out.push_back(edge{handle{low}, 0});
+        if (high)
+            out.push_back(edge{handle{high}, 1});
+
+        return out;
+    }
+
+    /**
+     * @brief Return the view roots as a small vector of handles
+     */
+    auto roots() const {
+        return std::vector<handle>{handle{root}};
+    }
+};
+
+static_assert(graph::external_dag_view<cudd_view>, "cudd_view should model external_dag_view");

--- a/include/expression_view.hpp
+++ b/include/expression_view.hpp
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) 2025 Alan Jowett
+/**
+ * @file expression_view.hpp
+ * @brief Adapter exposing the expression AST as a graph::external_dag_view
+ *
+ * This adapter provides a thin view over the variant-based AST defined in
+ * `expression_types.hpp`. It models `graph::external_dag_view` by providing
+ * nested `handle`, `edge`, and the `children()` / `roots()` methods used by
+ * generic graph algorithms in `graph.hpp`.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <variant>
+#include <vector>
+
+#include "expression_types.hpp"
+#include "graph.hpp"
+#include "graph_concepts.hpp"
+
+struct expression_view {
+    using expr_t = my_expression;
+
+    /**
+     * @brief Opaque handle representing a pointer into the expression AST
+     *
+     * `stable_key()` returns a stable integer derived from the pointer value
+     * and is used by graph algorithms for memoization and hashing. The
+     * `debug_address()` method is provided for optional diagnostics and may be
+     * used when available.
+     */
+    struct handle {
+        const expr_t* p = nullptr;
+        std::uint64_t stable_key() const noexcept {
+            return static_cast<std::uint64_t>(reinterpret_cast<std::uintptr_t>(p));
+        }
+        const void* debug_address() const noexcept {
+            return static_cast<const void*>(p);
+        }
+        friend bool operator==(const handle& a, const handle& b) noexcept {
+            return a.p == b.p;
+        }
+        friend bool operator!=(const handle& a, const handle& b) noexcept {
+            return a.p != b.p;
+        }
+    };
+
+    /**
+     * @brief Edge descriptor returned by `children()`
+     *
+     * The `branch` integer encodes a lightweight branch label: for binary
+     * operators 0==left, 1==right; for unary operators the branch is 0.
+     */
+    struct edge {
+        handle tgt;
+        int branch = 0;  // 0 = left/first, 1 = right/second (for binary ops)
+        handle target() const noexcept {
+            return tgt;
+        }
+        int label() const noexcept {
+            return branch;
+        }
+    };
+
+    /// Pointer to the root expression node for this view
+    const expr_t* root = nullptr;
+
+    expression_view() = default;
+    explicit expression_view(const expr_t& e) : root(&e) {}
+    explicit expression_view(const expr_t* p) : root(p) {}
+
+    /**
+     * @brief Return the outgoing edges for node `h`
+     *
+     * Returns an owned `std::vector<edge>` containing the logical children of
+     * the expression node. Binary operators yield two edges (when both
+     * children exist); `my_not` yields a single child; `my_variable` yields no
+     * children.
+     *
+     * @param h Node handle for which children are requested
+     * @return `std::vector<edge>` listing outgoing edges
+     */
+    auto children(handle h) const {
+        std::vector<edge> out;
+        if (!h.p)
+            return out;
+
+        std::visit(
+            [&](auto const& v) {
+                using T = std::decay_t<decltype(v)>;
+                if constexpr (std::is_same_v<T, my_and> || std::is_same_v<T, my_or>
+                              || std::is_same_v<T, my_xor>) {
+                    if (v.left)
+                        out.push_back(edge{handle{v.left.get()}, 0});
+                    if (v.right)
+                        out.push_back(edge{handle{v.right.get()}, 1});
+                } else if constexpr (std::is_same_v<T, my_not>) {
+                    if (v.expr)
+                        out.push_back(edge{handle{v.expr.get()}, 0});
+                } else if constexpr (std::is_same_v<T, my_variable>) {
+                    // no children
+                }
+            },
+            *h.p);
+
+        return out;
+    }
+
+    /**
+     * @brief Return the root handles for the view
+     *
+     * The adapter returns a single-element vector containing the root
+     * expression pointer wrapped in a `handle`.
+     */
+    auto roots() const {
+        return std::vector<handle>{handle{root}};
+    }
+};
+
+static_assert(graph::external_dag_view<expression_view>,
+              "expression_view should model external_dag_view");

--- a/include/graph.hpp
+++ b/include/graph.hpp
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) 2025 Alan Jowett
+
+#pragma once
+#include <any>
+#include <functional>
+#include <queue>
+#include <span>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+#include "graph_concepts.hpp"
+
+namespace graph {
+
+/**
+ * @brief Compute a topological order of nodes reachable from `roots`
+ *
+ * Performs a BFS discovery followed by Kahn's algorithm to produce a weak
+ * topological ordering of the subgraph reachable from the provided `roots`.
+ *
+ * @tparam G A type modeling `external_dag_view`.
+ * @param g The DAG view.
+ * @param roots An input-range of root handles to start discovery from.
+ * @return A `std::vector` of handles in topological order.
+ * @throws std::logic_error if a cycle is detected.
+ *
+ * Complexity: linear in the number of discovered nodes plus edges.
+ */
+template <external_dag_view G>
+std::vector<typename G::handle> topo_order(const G& g, std::ranges::input_range auto roots) {
+    /**
+     * Implied concepts:
+     * - `typename G::handle` must model `graph::node_handle` (stable_key(), equality).
+     * - `decltype(g.children(h))` must model `graph::children_range` whose
+     *   element type models `graph::edge_ref`.
+     * - `graph::has_debug_address` is optional and not required by these
+     *   algorithms; it can be used by callers for diagnostics when available.
+     */
+    using H = typename G::handle;
+    static_assert(graph::node_handle<H>, "G::handle must model graph::node_handle");
+
+    std::unordered_map<std::uint64_t, std::size_t> indeg;
+    std::vector<H> order;
+
+    // 1) Build indegrees by a forward sweep from roots
+    std::vector<H> frontier(std::begin(roots), std::end(roots));
+    std::unordered_map<std::uint64_t, H> seen;
+
+    auto add = [&](H h) { seen.emplace(h.stable_key(), h); };
+    for (auto& r : frontier)
+        add(r);
+
+    // BFS to discover nodes and indegrees
+    for (std::size_t i = 0; i < frontier.size(); ++i) {
+        H u = frontier[i];
+        for (auto&& e : g.children(u)) {
+            H v = e.target();
+            ++indeg[v.stable_key()];
+            if (!seen.count(v.stable_key())) {
+                add(v);
+                frontier.push_back(v);
+            }
+        }
+    }
+
+    // 2) Kahn’s algorithm
+    std::queue<H> q;
+    for (auto& [k, h] : seen) {
+        if (!indeg.count(k))
+            q.push(h);  // indegree 0
+    }
+
+    while (!q.empty()) {
+        H u = q.front();
+        q.pop();
+        order.push_back(u);
+        for (auto&& e : g.children(u)) {
+            H v = e.target();
+            auto& d = indeg[v.stable_key()];
+            if (--d == 0)
+                q.push(v);
+        }
+    }
+
+    if (order.size() != seen.size())
+        throw std::logic_error("cycle detected (not a DAG)");
+
+    return order;
+}
+
+/**
+ * @brief Post-order fold over the DAG with memoization
+ *
+ * Performs a memoized post-order traversal (children-first) starting at
+ * `root`. For each visited node the provided `combine` function is invoked
+ * with the graph view, the node handle, and a `std::span` of child results in
+ * canonical post-order. The `combine` must return a value convertible to
+ * `R`.
+ *
+ * @tparam G A type modeling `external_dag_view`.
+ * @tparam R The result type produced by `combine`.
+ * @tparam Combine Callable type: `R(const G&, typename G::handle, std::span<const R>)`.
+ * @param g The DAG view.
+ * @param root The starting node handle.
+ * @param combine A callable that computes the node result from child results.
+ * @return The folded result of type `R` for the root node.
+ */
+template <external_dag_view G, typename R, class Combine>
+R postorder_fold(const G& g, typename G::handle root, Combine&& combine) {
+    /**
+     * Implied concepts and notes:
+     * - `typename G::handle` must model `graph::node_handle`.
+     * - `g.children(h)` must be a `graph::children_range` producing elements
+     *   that model `graph::edge_ref`.
+     * - If `graph::has_debug_address<H>` is available, callers may use it for
+     *   diagnostics; algorithms rely on `stable_key()` for memoization.
+     */
+    using H = typename G::handle;
+    static_assert(graph::node_handle<H>, "G::handle must model graph::node_handle");
+    std::unordered_map<std::uint64_t, R> memo;
+
+    std::function<R(H)> dfs = [&](H u) -> R {
+        auto k = u.stable_key();
+        if (auto it = memo.find(k); it != memo.end())
+            return it->second;
+
+        std::vector<R> child_vals;
+        for (auto&& e : g.children(u))
+            child_vals.push_back(dfs(e.target()));
+
+        R r = combine(g, u, std::span<const R>(child_vals));
+        memo.emplace(k, r);
+        return r;
+    };
+
+    return dfs(root);
+}
+}  // namespace graph

--- a/include/graph_concepts.hpp
+++ b/include/graph_concepts.hpp
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) 2025 Alan Jowett
+
+#pragma once
+#include <concepts>
+#include <cstdint>
+#include <ranges>
+#include <type_traits>
+
+namespace graph {
+
+/**
+ * @brief Handle concept for nodes in external DAG views
+ *
+ * A handle type represents a stable identifier for a node. Requirements:
+ * - `stable_key()` returns a value convertible to `std::uint64_t` suitable
+ *   for use as a key in memoization/hash maps.
+ * - equality (`==`, `!=`) must be provided.
+ * - the type must be `std::copyable`.
+ *
+ * This concept intentionally makes no assumptions about underlying storage
+ * (pointer, integer, small-value type) beyond copyability and stable_key().
+ */
+template <class H>
+concept node_handle = std::copyable<H> && requires(H h) {
+    { h.stable_key() } -> std::convertible_to<std::uint64_t>;  // memo key
+    { h == h } -> std::same_as<bool>;
+    { h != h } -> std::same_as<bool>;
+};
+
+/**
+ * @brief Optional: handle exposes a debug address
+ *
+ * Some handle types provide a `debug_address()` accessor that returns either
+ * a `const void*` or `std::uintptr_t`. This is only used for diagnostics and
+ * for producing stable human-readable IDs; it is optional for algorithms.
+ * Use `if constexpr (has_debug_address<H>)` to detect availability.
+ */
+template <class H>
+concept has_debug_address = (requires(H h) {
+                                { h.debug_address() } -> std::convertible_to<const void*>;
+                            }) || (requires(H h) {
+                                { h.debug_address() } -> std::convertible_to<std::uintptr_t>;
+                            });
+
+/**
+ * @brief Edge reference concept
+ *
+ * Models an edge-like view returned from a node's children range. Minimal
+ * requirements:
+ * - `e.target()` returns a value convertible to the node handle type `H`.
+ * - optionally an edge label may be available via `e.label()`.
+ */
+template <class E, class H>
+concept edge_ref = requires(const E& e) {
+    { e.target() } -> std::convertible_to<H>;
+    // Optional: edge label/weight (ignored by algorithms that don't need it)
+    // { e.label() } -> /* any type */;
+};
+
+/**
+ * @brief Children range concept
+ *
+ * A children range is any `std::ranges::input_range` whose `range_value_t`
+ * (or reference) models `edge_ref<..., H>`. Implementations are free to
+ * return owned containers (e.g. `std::vector<E>`), borrowed views, or
+ * adaptor-produced ranges.
+ */
+template <class R, class H>
+concept children_range = std::ranges::input_range<R> && requires(R r) {
+    requires edge_ref<std::ranges::range_value_t<R>, H>
+                 || edge_ref<std::remove_cvref_t<std::ranges::range_reference_t<R>>, H>;
+};
+
+/**
+ * @brief External DAG view concept
+ *
+ * Types that model `external_dag_view` expose a nested `handle` type and
+ * provide the following operations:
+ * - `g.children(h)` returns a children range yielding elements convertible
+ *   to edge-like objects whose `target()` yields a `handle`.
+ * - optionally `g.roots()` returns an input-range of root handles.
+ *
+ * This abstraction decouples algorithms from concrete graph storage
+ * implementations and enables generic traversal utilities.
+ */
+template <class G>
+concept external_dag_view = requires(const G& g, typename G::handle h) {
+    typename G::handle;
+    requires node_handle<typename G::handle>;
+    // Children of a node as a range of edges:
+    requires std::ranges::input_range<decltype(g.children(h))>;
+    requires children_range<decltype(g.children(h)), typename G::handle>;
+    // Roots are optional; many algorithms accept an explicit root list
+    requires std::ranges::input_range<decltype(g.roots())>;  // optional but nice to have
+};
+
+}  // namespace graph

--- a/include/teddy_view.hpp
+++ b/include/teddy_view.hpp
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) 2025 Alan Jowett
+/**
+ * @file teddy_view.hpp
+ * @brief TeDDy adapter implementing graph::external_dag_view
+ *
+ * Provides a lightweight adapter over TeDDy's internal node representation
+ * exposing `handle`, `edge`, `children()`, and `roots()` used by generic
+ * graph algorithms.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <libteddy/core.hpp>
+#include <vector>
+
+#include "graph_concepts.hpp"
+
+struct teddy_view {
+    using node_t = teddy::bdd_manager::diagram_t::node_t;
+
+    /**
+     * @brief Node handle wrapper for TeDDy nodes
+     *
+     * `stable_key()` returns a stable integer derived from the node pointer
+     * and is suitable for hashing/memoization by algorithms.
+     */
+    struct handle {
+        node_t* p = nullptr;
+        std::uint64_t stable_key() const noexcept {
+            return static_cast<std::uint64_t>(reinterpret_cast<std::uintptr_t>(p));
+        }
+        const void* debug_address() const noexcept {
+            return static_cast<const void*>(p);
+        }
+        friend bool operator==(const handle& a, const handle& b) noexcept {
+            return a.p == b.p;
+        }
+        friend bool operator!=(const handle& a, const handle& b) noexcept {
+            return a.p != b.p;
+        }
+    };
+
+    /**
+     * @brief Edge descriptor returned by `children()`
+     */
+    struct edge {
+        handle tgt;
+        int branch = 0;  // 0 = false/low, 1 = true/high
+        handle target() const noexcept {
+            return tgt;
+        }
+        int label() const noexcept {
+            return branch;
+        }
+    };
+
+    const teddy::bdd_manager* manager{};
+    teddy::bdd_manager::diagram_t diagram;
+
+    teddy_view() = default;
+    teddy_view(const teddy::bdd_manager* m, const teddy::bdd_manager::diagram_t& d)
+        : manager(m), diagram(d) {}
+
+    /**
+     * @brief Return the child edges for node `h`.
+     *
+     * Returns an empty vector for null or terminal nodes. Binary nodes
+     * typically yield two edges (low and high children).
+     */
+    auto children(handle h) const {
+        std::vector<edge> out;
+        node_t* n = h.p;
+        if (!n || n->is_terminal())
+            return out;
+
+        node_t* low = n->get_son(0);
+        if (low)
+            out.push_back(edge{handle{low}, 0});
+
+        node_t* high = n->get_son(1);
+        if (high)
+            out.push_back(edge{handle{high}, 1});
+
+        return out;
+    }
+
+    /**
+     * @brief Return the root handle for the diagram
+     */
+    auto roots() const {
+        return std::vector<handle>{handle{diagram.unsafe_get_root()}};
+    }
+};
+
+static_assert(graph::external_dag_view<teddy_view>, "teddy_view should model external_dag_view");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,10 @@ add_executable(unit_tests
     unit/test_node_table_generator.cpp
     unit/test_teddy_convert.cpp
     unit/test_teddy_iterator.cpp
+    unit/test_teddy_view.cpp
+    unit/test_cudd_view.cpp
+    unit/test_graph.cpp
+    unit/test_expression_view.cpp
     # Uncomment to include example tests for demonstration:
     # unit/test_example.cpp
 )

--- a/tests/unit/test_cudd_view.cpp
+++ b/tests/unit/test_cudd_view.cpp
@@ -1,0 +1,63 @@
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <cudd/cuddObj.hh>
+#include <unordered_set>
+
+#include "cudd_view.hpp"
+#include "graph.hpp"
+#include "graph_concepts.hpp"
+
+TEST_CASE("cudd_view models external_dag_view and preserves complement semantics") {
+    static_assert(graph::external_dag_view<cudd_view>);
+
+    // Build simple BDD: f = x0 XOR x1 = (x0 & !x1) | (!x0 & x1)
+    // Using Cudd C++ API via BDD wrapper
+    Cudd bdd_mgr;
+    BDD x0 = bdd_mgr.bddVar(0);
+    BDD x1 = bdd_mgr.bddVar(1);
+
+    BDD f = x0.Xor(x1);
+
+    // Get raw DdNode* for the root (CUDD pointer). Use manager from bdd_mgr
+    DdNode* root = f.getNode();
+
+    cudd_view view(&bdd_mgr, root);
+
+    // Use graph algorithms to discover nodes and fold values.
+    auto roots = view.roots();
+    REQUIRE(roots.size() == 1);
+
+    // Topological order from graph::topo_order
+    auto order = graph::topo_order(view, roots);
+    REQUIRE(!order.empty());
+
+    // Use postorder_fold to compute the set of visited stable_keys
+    auto key_set = graph::postorder_fold<cudd_view, std::unordered_set<std::uint64_t>>(
+        view, roots[0],
+        [](auto const& g, auto h, std::span<const std::unordered_set<std::uint64_t>> child_vals) {
+            std::unordered_set<std::uint64_t> s;
+            for (auto const& cs : child_vals)
+                s.insert(cs.begin(), cs.end());
+            s.insert(h.stable_key());
+            return s;
+        });
+
+    // The number of unique stable keys discovered by folding should equal topo_order size
+    REQUIRE(key_set.size() == order.size());
+
+    // Complement check: ensure complemented root is treated as distinct handle
+    DdNode* comp_root = Cudd_Not(root);
+    cudd_view view2(&bdd_mgr, comp_root);
+    auto order2 = graph::topo_order(view2, view2.roots());
+    REQUIRE(order2.size() == order.size());
+
+    // Roots must differ (complement bit preserved)
+    REQUIRE(view.roots()[0].stable_key() != view2.roots()[0].stable_key());
+
+    // Immediate children of the root should be complemented versions (stable keys differ)
+    auto ch = view.children(view.roots()[0]);
+    auto ch2 = view2.children(view2.roots()[0]);
+    REQUIRE(ch.size() == ch2.size());
+    for (size_t i = 0; i < ch.size(); ++i)
+        REQUIRE(ch[i].target().stable_key() != ch2[i].target().stable_key());
+}

--- a/tests/unit/test_expression_view.cpp
+++ b/tests/unit/test_expression_view.cpp
@@ -1,0 +1,53 @@
+#include <catch2/catch_all.hpp>
+#include <cstdint>
+#include <unordered_set>
+
+#include "expression_view.hpp"
+#include "graph.hpp"
+
+TEST_CASE("expression_view models external_dag_view and algorithms work", "[expression_view]") {
+    using view_t = expression_view;
+
+    // build AST: (a AND b) OR (NOT c)
+    auto left_leaf = std::make_unique<my_expression>(my_variable{"a"});
+    auto right_leaf = std::make_unique<my_expression>(my_variable{"b"});
+    auto mid_and =
+        std::make_unique<my_expression>(my_and{std::move(left_leaf), std::move(right_leaf)});
+
+    auto not_leaf = std::make_unique<my_expression>(my_variable{"c"});
+    auto mid_not = std::make_unique<my_expression>(my_not{std::move(not_leaf)});
+
+    auto root = my_expression{my_or{std::move(mid_and), std::move(mid_not)}};
+
+    view_t v(&root);
+
+    STATIC_REQUIRE(graph::external_dag_view<view_t>);
+
+    // collect topo order
+    auto topo = graph::topo_order(v, v.roots());
+    REQUIRE(!topo.empty());
+
+    // collect postorder fold: produce set of stable_keys
+    auto folded = graph::postorder_fold<view_t, std::unordered_set<std::uint64_t>>(
+        v, v.roots().front(),
+        [](const view_t& /*g*/, const view_t::handle& h,
+           std::span<const std::unordered_set<std::uint64_t>> child_keys) {
+            std::unordered_set<std::uint64_t> acc;
+            acc.insert(h.stable_key());
+            for (auto const& ck : child_keys)
+                for (auto k : ck)
+                    acc.insert(k);
+            return acc;
+        });
+
+    // all topo nodes' stable keys should be in the folded set
+    for (auto const& h : topo) {
+        REQUIRE(folded.find(h.stable_key()) != folded.end());
+    }
+
+    // verify children mapping for the root: should have two children
+    auto roots = v.roots();
+    REQUIRE(roots.size() == 1);
+    auto ch = v.children(roots.front());
+    REQUIRE(ch.size() == 2);
+}

--- a/tests/unit/test_graph.cpp
+++ b/tests/unit/test_graph.cpp
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) 2025 Alan Jowett
+
+/**
+ * @file test_graph.hpp
+ * @brief Unit tests for graph concepts and utilities.
+ *
+ * @author Alan Jowett
+ * @date 2025
+ */
+
+#include <catch2/catch_all.hpp>
+#include <cstdint>
+#include <vector>
+
+#include "graph.hpp"
+#include "graph_iterator_concepts.hpp"
+
+// Storage:
+struct AdjDAG {
+    struct Edge {
+        std::uint32_t to;
+        float w;
+    };
+    std::vector<std::vector<Edge>> out;  // 0..N-1
+    std::vector<std::uint32_t> roots_;
+};
+
+// Handle & EdgeRef:
+struct AdjHandle {
+    std::uint32_t id{};
+    std::uint64_t stable_key() const {
+        return id;
+    }
+    const void* debug_address() const {
+        return nullptr;
+    }
+    friend bool operator==(AdjHandle a, AdjHandle b) {
+        return a.id == b.id;
+    }
+    friend bool operator!=(AdjHandle a, AdjHandle b) {
+        return !(a == b);
+    }
+};
+
+struct AdjEdge {
+    AdjHandle tgt;
+    float w;
+    AdjHandle target() const {
+        return tgt;
+    }
+    float label() const {
+        return w;
+    }
+};
+
+struct AdjView {
+    using handle = AdjHandle;
+
+    const AdjDAG* g{};
+    auto children(handle h) const {
+        std::vector<AdjEdge> outv;
+        const auto& src = g->out[h.id];
+        outv.reserve(src.size());
+        for (const auto& e : src)
+            outv.push_back(AdjEdge{AdjHandle{e.to}, e.w});
+        return outv;
+    }
+    auto roots() const {
+        std::vector<AdjHandle> rv;
+        rv.reserve(g->roots_.size());
+        for (auto x : g->roots_)
+            rv.push_back(AdjHandle{x});
+        return rv;
+    }
+};
+static_assert(graph::external_dag_view<AdjView>, "AdjView should model external_dag_view");
+
+// Test topo_order:
+TEST_CASE("topo_order on AdjView", "[graph][topo_order]") {
+    AdjDAG dag;
+    dag.out = {
+        {{1, 1.0f}, {2, 2.0f}},  // 0 -> 1,2
+        {{3, 1.0f}},             // 1 -> 3
+        {{3, 1.0f}},             // 2 -> 3
+        {}                       // 3 ->
+    };
+    dag.roots_ = {0};
+
+    AdjView view{&dag};
+    auto order = graph::topo_order(view, view.roots());
+
+    REQUIRE(order.size() == 4);
+    REQUIRE(order[0].id == 0);
+    REQUIRE((order[1].id == 1 || order[1].id == 2));
+    REQUIRE((order[2].id == 1 || order[2].id == 2));
+    REQUIRE(order[1].id != order[2].id);
+    REQUIRE(order[3].id == 3);
+}
+
+// Test postorder_fold:
+TEST_CASE("postorder_fold on AdjView", "[graph][postorder_fold]") {
+    AdjDAG dag;
+    dag.out = {
+        {{1, 1.0f}, {2, 2.0f}},  // 0 -> 1,2
+        {{3, 1.0f}},             // 1 -> 3
+        {{3, 1.0f}},             // 2 -> 3
+        {}                       // 3 ->
+    };
+    dag.roots_ = {0};
+    AdjView view{&dag};
+    auto sum_weights = graph::postorder_fold<AdjView, float>(
+        view, AdjHandle{0}, [](const AdjView& g, AdjHandle h, std::span<const float> child_sums) {
+            float total = 0.0f;
+            for (const auto& e : g.children(h)) {
+                total += e.label();  // edge weight
+            }
+            for (float cs : child_sums) {
+                total += cs;  // sum from children
+            }
+            return total;
+        });
+    REQUIRE(sum_weights == Catch::Approx(5.0f));  // 1.0 + 2.0 + 1.0 + 1.0
+}

--- a/tests/unit/test_teddy_view.cpp
+++ b/tests/unit/test_teddy_view.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) 2025 Alan Jowett
+
+#include <catch2/catch_all.hpp>
+#include <libteddy/core.hpp>
+
+#include "graph.hpp"
+#include "teddy_test_utils.hpp"
+#include "teddy_view.hpp"
+
+TEST_CASE("teddy_view models external_dag_view and integrates with algorithms", "[teddy][view]") {
+    using namespace teddy::ops;
+
+    // Create a small TeDDy manager with 2 variables
+    teddy::bdd_manager manager(2, 1000);
+
+    // Build a simple BDD: f = x0 AND (NOT x1)  i.e. x0 & !x1
+    auto x0 = manager.variable(0);
+    auto x1 = manager.variable(1);
+    auto not_x1 = manager.apply<XOR>(x1, manager.constant(1));
+    auto f = manager.apply<AND>(x0, not_x1);
+
+    teddy_view view(&manager, f);
+
+    // Concept check
+    STATIC_REQUIRE(graph::external_dag_view<teddy_view>);
+
+    // roots should contain the root handle
+    auto roots = view.roots();
+    REQUIRE(!roots.empty());
+
+    // topo_order should return a vector of handles
+    auto order = graph::topo_order(view, roots);
+    REQUIRE(!order.empty());
+
+    // postorder_fold: count variable nodes (non-terminals)
+    auto count = graph::postorder_fold<teddy_view, int>(
+        view, order[0],
+        [](const teddy_view& g, teddy_view::handle h, std::span<const int> child_sums) {
+            int sum = 0;
+            for (auto&& e : g.children(h)) {
+                // label isn't used here
+            }
+            for (int v : child_sums)
+                sum += v;
+            // if node is non-terminal count 1, else 0
+            return h.p && !h.p->is_terminal() ? (1 + sum) : sum;
+        });
+
+    REQUIRE(count == 2);
+}


### PR DESCRIPTION
This pull request introduces a generic graph abstraction layer for DAGs (Directed Acyclic Graphs) in C++, along with adapters for several backends (CUDD, TeDDy, and an expression AST), and provides reusable algorithms for traversing and folding over these graphs. It also includes comprehensive unit tests for these new components. The main themes are the introduction of generic graph concepts, backend adapters, reusable algorithms, and associated tests.

**Graph abstraction and concepts:**

* Introduced `graph_concepts.hpp`, which defines generic C++ concepts for DAG node handles, edge references, children ranges, and the `external_dag_view` abstraction, enabling generic graph algorithms to work with various backends.

**Reusable graph algorithms:**

* Added `graph.hpp`, providing generic algorithms such as `topo_order` (topological sort) and `postorder_fold` (memoized post-order fold) for any type modeling `external_dag_view`.

**Backend adapters implementing the graph view:**

* Added `cudd_view.hpp`, an adapter exposing CUDD BDDs as an `external_dag_view`, preserving complement-edge semantics.
* Added `teddy_view.hpp`, an adapter for TeDDy BDDs, providing a compatible DAG view for generic algorithms.
* Added `expression_view.hpp`, an adapter for a variant-based expression AST, making it traversable with the same generic graph algorithms.

**Testing:**

* Added new unit tests for each adapter and the graph algorithms, ensuring correctness and compatibility. Tests cover CUDD, TeDDy, and expression AST adapters, as well as the generic algorithms. [[1]](diffhunk://#diff-4461c617ceae0c7e0206622aacdf555aedd62eb129c2efb74c84fa1567bcbe0dR103-R106) [[2]](diffhunk://#diff-a183f4c987ff6f459e0d1abf092f184ed991c9572bb345a81c071f2c7a8aedc1R1-R63) [[3]](diffhunk://#diff-249eacfbea2882d407422315cece5399c6b39e8eb1bbfbf1d9b57ffad32efbfbR1-R53)

These changes together create a flexible, reusable infrastructure for graph algorithms across multiple backends, with strong compile-time guarantees and comprehensive tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graph view adapters for CUDD, TeDDy, and expression ASTs to present external DAG views.
  * Introduced generic graph utilities: topological ordering and memoized postorder folding.

* **Tests**
  * Added unit tests validating the new adapters and traversal utilities, including integration scenarios and concept conformance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->