### PR TITLE
Update README with project retirement notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# NOTE: This project is being retired in favor of [DagIR](https://github.com/Alan-Jowett/dagir) - Traverse external DAGs without copying and render them anywhere: DagIR builds a lightweight IR for DOT, Mermaid, or JSON — header-only, C++20, cross-platform.
+
+This repo is being made read-only and kept for historical sake.
+
 # BDD Expression Converter
 
 [![CI/CD Pipeline](https://github.com/Alan-Jowett/bdd_test/actions/workflows/ci.yml/badge.svg)](https://github.com/Alan-Jowett/bdd_test/actions/workflows/ci.yml)


### PR DESCRIPTION
This pull request updates the `README.md` to announce the retirement of the project in favor of a new project, DagIR, and clarifies the repository's new read-only status.

Project retirement and archival:

* Added a prominent note at the top of `README.md` stating that the project is being retired, with a link to the successor project DagIR, and that this repository is now read-only and kept for historical purposes.